### PR TITLE
fixed bnb symbol for coingecko

### DIFF
--- a/src/assets/network.js
+++ b/src/assets/network.js
@@ -49,7 +49,7 @@ export default {
     name: 'Binance Smart Chain',
     type: 'network',
     code: 'BNB',
-    coinGeckoId: 'binance-coin',
+    coinGeckoId: 'binancecoin',
     color: '#f9a825',
     decimals: 18,
     fees: {


### PR DESCRIPTION
### Description
This PR fixes the wrong symbol name of BNB for coingecko price feed.

### Submission Checklist :pencil:
- [x ] Fix symbol of BNB for coingecko purposes binance-coin => binancecoin

