### PR TITLE
fix: fuse coinGeckoId

### DIFF
--- a/src/assets/native.ts
+++ b/src/assets/native.ts
@@ -89,7 +89,7 @@ const nativeAssets: AssetMap = {
     chain: ChainId.Fuse,
     type: 'native',
     code: 'FUSE',
-    coinGeckoId: 'fuse',
+    coinGeckoId: 'fuse-network-token',
     color: '#46e8b6',
     decimals: 18
   },


### PR DESCRIPTION
Fixed the CoinGeckoId for fuse token, it was causing incorrect price in the liquality wallet

Link for verification:
https://api.coingecko.com/api/v3/simple/price?ids=fuse-network-token&vs_currencies=usd