### PR TITLE
fix: bad matching asset & asset code

### DIFF
--- a/src/assets/erc20/arbitrum-tokens.json
+++ b/src/assets/erc20/arbitrum-tokens.json
@@ -1,7 +1,7 @@
 {
   "ARBUSDC": {
     "name": "Arbitrum USD Coin",
-    "code": "USDC",
+    "code": "ARBUSDC",
     "decimals": 6,
     "contractAddress": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
     "color": "#5b31b9",
@@ -10,7 +10,7 @@
   },
   "ARBUSDT": {
     "name": "Arbitrum Tether USD",
-    "code": "USDT",
+    "code": "ARBUSDT",
     "decimals": 6,
     "contractAddress": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
     "color": "#5b31f9",
@@ -19,7 +19,7 @@
   },
   "ARBDAI": {
     "name": "Arbitrum DAI",
-    "code": "DAI",
+    "code": "ARBDAI",
     "decimals": 18,
     "contractAddress": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
     "color": "#3b31a9",

--- a/src/assets/erc20/avalanche-tokens.json
+++ b/src/assets/erc20/avalanche-tokens.json
@@ -1,7 +1,7 @@
 {
   "WBTC.e": {
     "name": "Avax Wrapped Bitcoin",
-    "code": "WBTC",
+    "code": "WBTC.e",
     "decimals": 8,
     "contractAddress": "0x50b7545627a5162f82a992c33b87adc75187b218",
     "color": "#5b3159",
@@ -10,7 +10,7 @@
   },
   "USDC.e": {
     "name": "Avax USD Coin",
-    "code": "USDC",
+    "code": "USDC.e",
     "decimals": 6,
     "contractAddress": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
     "color": "#5b31b9",
@@ -19,7 +19,7 @@
   },
   "USDT.e": {
     "name": "Avax Tether USD",
-    "code": "USDT",
+    "code": "USDT.e",
     "decimals": 6,
     "contractAddress": "0xc7198437980c041c805a1edcba50c1ce5db95118",
     "color": "#5b31f9",

--- a/src/assets/erc20/ethereum-tokens.json
+++ b/src/assets/erc20/ethereum-tokens.json
@@ -1888,7 +1888,7 @@
     "coinGeckoId": "storm"
   },
   "WMATIC": {
-    "name": "Wrapped Matic Network Token",
+    "name": "Matic Token",
     "code": "MATIC",
     "decimals": 18,
     "contractAddress": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",

--- a/src/assets/erc20/polygon-tokens.json
+++ b/src/assets/erc20/polygon-tokens.json
@@ -1,7 +1,7 @@
 {
   "PWETH": {
     "name": "Polygon Wrapped Ether",
-    "code": "WETH",
+    "code": "PWETH",
     "decimals": 18,
     "contractAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
     "color": "#5b3159",
@@ -10,7 +10,7 @@
   },
   "PUSDC": {
     "name": "Polygon USD Coin",
-    "code": "USDC",
+    "code": "PUSDC",
     "decimals": 6,
     "contractAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
     "color": "#5b31b9",
@@ -19,7 +19,7 @@
   },
   "PUSDT": {
     "name": "Polygon Tether USD",
-    "code": "USDT",
+    "code": "PUSDT",
     "decimals": 6,
     "contractAddress": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
     "color": "#5b31f9",
@@ -28,7 +28,7 @@
   },
   "PBUSD": {
     "name": "Polygon BUSD",
-    "code": "BUSD",
+    "code": "PBUSD",
     "decimals": 18,
     "contractAddress": "0xdab529f40e671a1d4bf91361c21bf9f0c9712ab7",
     "color": "#5b31a9",
@@ -37,7 +37,7 @@
   },
   "PBNB": {
     "name": "Polygon BNB",
-    "code": "WBNB",
+    "code": "PBNB",
     "decimals": 18,
     "contractAddress": "0x3BA4c387f786bFEE076A58914F5Bd38d668B42c3",
     "color": "#1b31a9",
@@ -45,7 +45,7 @@
   },
   "PLINK": {
     "name": "Polygon LINK",
-    "code": "LINK",
+    "code": "PLINK",
     "decimals": 18,
     "contractAddress": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
     "color": "#2b31a9",
@@ -54,7 +54,7 @@
   },
   "PDAI": {
     "name": "Polygon DAI",
-    "code": "DAI",
+    "code": "PDAI",
     "decimals": 18,
     "contractAddress": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
     "color": "#3b31a9",
@@ -63,7 +63,7 @@
   },
   "POMG": {
     "name": "Polygon OMG",
-    "code": "OMG",
+    "code": "POMG",
     "decimals": 18,
     "contractAddress": "0x62414d03084eeb269e18c970a21f45d2967f0170",
     "color": "#4b31a9",
@@ -72,16 +72,16 @@
   },
   "PWBTC": {
     "name": "Polygon WBTC",
-    "code": "WBTC",
+    "code": "PWBTC",
     "decimals": 8,
     "contractAddress": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
     "color": "#4b31a9",
     "coinGeckoId": "wrapped-bitcoin",
     "matchingAsset": "WBTC"
   },
-  "PFANTOM": {
+  "PFTM": {
     "name": "Polygon Fantom",
-    "code": "FTM",
+    "code": "PFTM",
     "decimals": 18,
     "contractAddress": "0xc9c1c1c20b3658f8787cc2fd702267791f224ce1",
     "color": "#6b31a9",
@@ -90,7 +90,7 @@
   },
   "PENJ": {
     "name": "Polygon Enjin Coin",
-    "code": "ENJ",
+    "code": "PENJ",
     "decimals": 18,
     "contractAddress": "0x7ec26842f195c852fa843bb9f6d8b583a274a157",
     "color": "#6b31a9",
@@ -99,7 +99,7 @@
   },
   "PUNI": {
     "name": "Polygon Uniswap",
-    "code": "UNI",
+    "code": "PUNI",
     "decimals": 18,
     "contractAddress": "0xb33eaad8d922b1083446dc23f610c2567fb5180f",
     "color": "#6ba1a9",
@@ -108,7 +108,7 @@
   },
   "PGRT": {
     "name": "Polygon The Graph",
-    "code": "GRT",
+    "code": "PGRT",
     "decimals": 18,
     "contractAddress": "0x5fe2b58c013d7601147dcdd68c143a77499f5531",
     "color": "#6b31c9",
@@ -117,7 +117,7 @@
   },
   "PHUSD": {
     "name": "Polygon HUSD",
-    "code": "HUSD",
+    "code": "PHUSD",
     "decimals": 8,
     "contractAddress": "0x2088c47fc0c78356c622f79dba4cbe1ccfa84a91",
     "color": "#6b3ea9",
@@ -126,7 +126,7 @@
   },
   "PAAVE": {
     "name": "Polygon Aave",
-    "code": "AAVE",
+    "code": "PAAVE",
     "decimals": 18,
     "contractAddress": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
     "color": "#6b38a9",
@@ -135,7 +135,7 @@
   },
   "PSUSHI": {
     "name": "Polygon Sushi",
-    "code": "SUSHI",
+    "code": "PSUSHI",
     "decimals": 18,
     "contractAddress": "0x0b3f868e0be5597d5db7feb59e1cadbb0fdda50a",
     "color": "#6b37a9",
@@ -144,7 +144,7 @@
   },
   "P1INCH": {
     "name": "Polygon 1INCH",
-    "code": "1INCH",
+    "code": "P1INCH",
     "decimals": 18,
     "contractAddress": "0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f",
     "color": "#6b23a9",
@@ -153,7 +153,7 @@
   },
   "PUSDK": {
     "name": "Polygon USDK",
-    "code": "USDK",
+    "code": "PUSDK",
     "decimals": 18,
     "contractAddress": "0xd07a7fac2857901e4bec0d89bbdae764723aab86",
     "color": "#6cd1a9",
@@ -162,7 +162,7 @@
   },
   "PHOT": {
     "name": "Polygon HoloToken",
-    "code": "HOT",
+    "code": "PHOT",
     "decimals": 18,
     "contractAddress": "0x0c51f415cf478f8d08c246a6c6ee180c5dc3a012",
     "color": "#8834ff",
@@ -180,7 +180,7 @@
   },
   "PCRV": {
     "name": "Polygon CRV",
-    "code": "CRV",
+    "code": "PCRV",
     "decimals": 18,
     "contractAddress": "0x172370d5cd63279efa6d502dab29171933a610af",
     "color": "#1a41e9",
@@ -189,7 +189,7 @@
   },
   "PCOMP": {
     "name": "Polygon Compound",
-    "code": "COMP",
+    "code": "PCOMP",
     "decimals": 18,
     "contractAddress": "0x8505b9d2254a7ae468c0e9dd10ccea3a837aef5c",
     "color": "#1a41f9",
@@ -198,7 +198,7 @@
   },
   "PZRX": {
     "name": "Polygon 0x",
-    "code": "ZRX",
+    "code": "PZRX",
     "decimals": 18,
     "contractAddress": "0x5559edb74751a0ede9dea4dc23aee72cca6be3d5",
     "color": "#302c3c",
@@ -207,7 +207,7 @@
   },
   "PTUSD": {
     "name": "Polygon TrueUSD",
-    "code": "TUSD",
+    "code": "PTUSD",
     "decimals": 18,
     "contractAddress": "0x2e1ad108ff1d8c782fcbbb89aad783ac49586756",
     "color": "#2b2e8f",
@@ -224,7 +224,7 @@
   },
   "PPOLY": {
     "name": "Polygon Polymath",
-    "code": "POLY",
+    "code": "PPOLY",
     "decimals": 18,
     "contractAddress": "0xcb059c5573646047d6d88dddb87b745c18161d3b",
     "color": "#4c5ae5",
@@ -233,7 +233,7 @@
   },
   "PMKR": {
     "name": "Polygon Maker",
-    "code": "MKR",
+    "code": "PMKR",
     "decimals": 18,
     "contractAddress": "0x6f7C932e7684666C9fd1d44527765433e01fF61d",
     "color": "#1abcec",
@@ -242,7 +242,7 @@
   },
   "PMANA": {
     "name": "Polygon Decentraland",
-    "code": "MANA",
+    "code": "PMANA",
     "decimals": 18,
     "contractAddress": "0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4",
     "color": "#bfb5ef",
@@ -251,7 +251,7 @@
   },
   "PBAT": {
     "name": "Polygon Basic Attention Token",
-    "code": "BAT",
+    "code": "PBAT",
     "decimals": 18,
     "contractAddress": "0x3cef98bb43d732e2f285ee605a8158cde967d219",
     "color": "#ff5200",
@@ -260,7 +260,7 @@
   },
   "PELON": {
     "name": "Polygon Dogelon MARS",
-    "code": "ELON",
+    "code": "PELON",
     "decimals": 18,
     "contractAddress": "0xe0339c80ffde91f3e20494df88d4206d86024cdf",
     "color": "#1a41fe",
@@ -269,7 +269,7 @@
   },
   "PSNX": {
     "name": "Polygon Synthetix Network Token",
-    "code": "SNX",
+    "code": "PSNX",
     "decimals": 18,
     "contractAddress": "0x50b728d8d964fd00c2d0aad81718b71311fef68a",
     "coinGeckoId": "havven",
@@ -277,7 +277,7 @@
   },
   "PBNT": {
     "name": "Polygon Bancor Network Token",
-    "code": "BNT",
+    "code": "PBNT",
     "decimals": 18,
     "contractAddress": "0xc26d47d5c33ac71ac5cf9f776d63ba292a4f7842",
     "color": "#000d2b",
@@ -286,7 +286,7 @@
   },
   "POCEAN": {
     "name": "Polygon OCEAN Protocol",
-    "code": "OCEAN",
+    "code": "POCEAN",
     "decimals": 18,
     "contractAddress": "0x282d8efce846a88b159800bd4130ad77443fa1a1",
     "color": "#1a413e",
@@ -295,7 +295,7 @@
   },
   "PWOO": {
     "name": "Polygon Wootrade Network",
-    "code": "WOO",
+    "code": "PWOO",
     "decimals": 18,
     "contractAddress": "0x1b815d120b3ef02039ee11dc2d33de7aa4a8c603",
     "color": "#1ba13e",
@@ -304,7 +304,7 @@
   },
   "PFET": {
     "name": "Polygon Fetch",
-    "code": "FET",
+    "code": "PFET",
     "decimals": 18,
     "contractAddress": "0x7583feddbcefa813dc18259940f76a02710a8905",
     "color": "#1bac3e",
@@ -312,17 +312,17 @@
     "matchingAsset": "FET"
   },
   "PWMATIC": {
-    "name": "Polygon Wrapped Matic Network Token",
-    "code": "WMATIC",
+    "name": "Wrapped Matic Token",
+    "code": "PWMATIC",
     "decimals": 18,
     "contractAddress": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
     "color": "#2b6cef",
     "coinGeckoId": "matic-network",
-    "matchingAsset": "WMATIC"
+    "matchingAsset": "MATIC"
   },
   "PCRO": {
     "name": "Polygon Crypto.com Chain",
-    "code": "CRO",
+    "code": "PCRO",
     "decimals": 8,
     "contractAddress": "0xada58df0f643d959c2a47c9d4d4c1a4defe3f11c",
     "color": "#1b6cef",
@@ -331,7 +331,7 @@
   },
   "PUMA": {
     "name": "Polygon UMA",
-    "code": "UMA",
+    "code": "PUMA",
     "decimals": 18,
     "contractAddress": "0x3066818837c5e6ed6601bd5a91b0762877a6b731",
     "color": "#ab6cef",
@@ -340,7 +340,7 @@
   },
   "PHEX": {
     "name": "Polygon HEX",
-    "code": "HEX",
+    "code": "PHEX",
     "decimals": 8,
     "contractAddress": "0x23d29d30e35c5e8d321e1dc9a8a61bfd846d4c5c",
     "color": "#ee6cef",
@@ -349,7 +349,7 @@
   },
   "PIOTX": {
     "name": "Polygon IoTeX",
-    "code": "IOTX",
+    "code": "PIOTX",
     "decimals": 18,
     "contractAddress": "0xf6372cdb9c1d3674e83842e3800f2a62ac9f3c66",
     "color": "#00d4d8",


### PR DESCRIPTION
Fixes [LIQ-1422](https://linear.app/liquality/issue/LIQ-1422/arbitrium-tokens-dollar-value-not-displayed-if-user-enable-multi) & [LIQ-1485](https://linear.app/liquality/issue/LIQ-1485/erc20-assets-code-for-avalanche-arbitrum-polygon-are-wrong-in#comment-d2dcc60e)